### PR TITLE
Support multiple entries for pre/post up/down

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -20,10 +20,10 @@ attribute :mtu,        kind_of: Integer
 attribute :mask,       kind_of: String
 attribute :network,    kind_of: String
 attribute :broadcast,  kind_of: String
-attribute :pre_up,     kind_of: String
-attribute :up,         kind_of: String
-attribute :post_up,    kind_of: String
-attribute :pre_down,   kind_of: String
-attribute :down,       kind_of: String
-attribute :post_down,  kind_of: String
+attribute :pre_up,     kind_of: Array, default: []
+attribute :up,         kind_of: Array, default: []
+attribute :post_up,    kind_of: Array, default: []
+attribute :pre_down,   kind_of: Array, default: []
+attribute :down,       kind_of: Array, default: []
+attribute :post_down,  kind_of: Array, default: []
 attribute :custom,     kind_of: Hash

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -20,10 +20,10 @@ attribute :mtu,        kind_of: Integer
 attribute :mask,       kind_of: String
 attribute :network,    kind_of: String
 attribute :broadcast,  kind_of: String
-attribute :pre_up,     kind_of: Array, default: []
-attribute :up,         kind_of: Array, default: []
-attribute :post_up,    kind_of: Array, default: []
-attribute :pre_down,   kind_of: Array, default: []
-attribute :down,       kind_of: Array, default: []
-attribute :post_down,  kind_of: Array, default: []
+attribute :pre_up,     kind_of: [String, Array]
+attribute :up,         kind_of: [String, Array]
+attribute :post_up,    kind_of: [String, Array]
+attribute :pre_down,   kind_of: [String, Array]
+attribute :down,       kind_of: [String, Array]
+attribute :post_down,  kind_of: [String, Array]
 attribute :custom,     kind_of: Hash

--- a/templates/default/interfaces.erb
+++ b/templates/default/interfaces.erb
@@ -35,23 +35,23 @@ iface <%= @device %> inet <%= @type %>
 <% if @mtu -%>
   mtu <%= @mtu %>
 <% end %>
-<% if @pre_up -%>
-  pre-up <%= @pre_up %>
+<% @pre_up.each do |x| -%>
+  pre-up <%= x %>
 <% end %>
-<% if @up -%>
-        up <%= @up %>
+<% @up.each do |x| -%>
+  up <%= x %>
 <% end %>
-<% if @post_up -%>
-        post-up <%= @post_up %>
+<% @post_up.each do |x| -%>
+  post-up <%= x %>
 <% end %>
-<% if @pre_down -%>
-        pre-down <%= @pre_down %>
+<% @pre_down.each do |x| -%>
+  pre-down <%= x %>
 <% end %>
-<% if @down -%>
-        down <%= @down %>
+<% @down.each do |x| -%>
+  down <%= x %>
 <% end %>
-<% if @post_down -%>
-        post-down <%= @post_down %>
+<% @post_down.each do |x| -%>
+  post-down <%= x %>
 <% end %>
 <% if @custom %>
 <% @custom.sort_by{ |instruc, command| instruc }.each do |instruc, command| -%>

--- a/templates/default/interfaces.erb
+++ b/templates/default/interfaces.erb
@@ -35,22 +35,22 @@ iface <%= @device %> inet <%= @type %>
 <% if @mtu -%>
   mtu <%= @mtu %>
 <% end %>
-<% @pre_up.each do |x| -%>
+<% Array(@pre_up).each do |x| -%>
   pre-up <%= x %>
 <% end %>
-<% @up.each do |x| -%>
+<% Array(@up).each do |x| -%>
   up <%= x %>
 <% end %>
-<% @post_up.each do |x| -%>
+<% Array(@post_up).each do |x| -%>
   post-up <%= x %>
 <% end %>
-<% @pre_down.each do |x| -%>
+<% Array(@pre_down).each do |x| -%>
   pre-down <%= x %>
 <% end %>
-<% @down.each do |x| -%>
+<% Array(@down).each do |x| -%>
   down <%= x %>
 <% end %>
-<% @post_down.each do |x| -%>
+<% Array(@post_down).each do |x| -%>
   post-down <%= x %>
 <% end %>
 <% if @custom %>


### PR DESCRIPTION
Converts each affected resource attribute to an array.  The template is updated to correctly write out each array member as a separate line, and the default value for the arrays is set to an empty array to simplify the template.

This should help address issue #18.
