### PR TITLE
Added option for including the allow-hotplug option for debian based interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 network_interface
 =================
 
+# Unreleased:
+
+v1.x.x (2015-08-13)
+- adding support for the allow-hotplug stanza (https://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_basic_syntax_of_etc_network_interfaces) mainly used in Debian.
+
+# Last Release: v1.0.0
+
 v1.0.0 (2014-03-03)
 -------------------
-
 - released version on community
-
 
 v1.0.0 (2014-02-24=5)
 -------------------

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'guilhem.lettron@youscribe.com'
 license 'Apache 2.0'
 description 'Installs/Configures network on Ubuntu and Debian'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.1'
+version '1.0.0'
 
 supports 'ubuntu', '>= 12.04'
 supports 'debian', '>= 6.0.8'

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -62,10 +62,10 @@ action :save do
       pre_down:     Chef::Recipe::NetworkInterfaces.value(:pre_down,   new_resource.device, new_resource, node),
       down:         Chef::Recipe::NetworkInterfaces.value(:down,       new_resource.device, new_resource, node),
       post_down:    Chef::Recipe::NetworkInterfaces.value(:post_down,  new_resource.device, new_resource, node),
-      custom:       Chef::Recipe::NetworkInterfaces.value(:custom,     new_resource.device, new_resource, node)
+      custom:       Chef::Recipe::NetworkInterfaces.value(:custom,     new_resource.device, new_resource, node),
+      hotplug:      Chef::Recipe::NetworkInterfaces.value(:hotplug,    new_resource.device, new_resource, node)
     )
     notifies :run, "execute[if_up #{new_resource.name}]", :immediately
-    notifies :create, 'ruby_block[Merge interfaces]', :delayed
   end
 
   new_resource.updated_by_last_action(if_up.updated_by_last_action?)

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -27,3 +27,4 @@ attribute :pre_down,   kind_of: String
 attribute :down,       kind_of: String
 attribute :post_down,  kind_of: String
 attribute :custom,     kind_of: Hash
+attribute :hotplug,    kind_of: [TrueClass, FalseClass], default: false

--- a/templates/default/interfaces.erb
+++ b/templates/default/interfaces.erb
@@ -1,6 +1,9 @@
 <% if @auto -%>
 auto <%= @device %>
 <% end %>
+<% if @hotplug -%>
+allow-hotplug <%= @device %>
+<% end %>
 iface <%= @device %> inet <%= @type %>
 <% if @address -%>
   address <%= @address %>
@@ -58,4 +61,3 @@ iface <%= @device %> inet <%= @type %>
         <%= instruc %> <%= command %>
 <% end %>
 <% end %>
-


### PR DESCRIPTION
Hi,
I added the option allow-hotplug to the cookbook. Left it as false by default to avoid any backwards compatibility problems.
I hope this helps.